### PR TITLE
docker-compose-buildのトリガー修正

### DIFF
--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -4,7 +4,7 @@ name: docker-compose-build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
`docker-compose-build` のトリガーのブランチ名が間違っていたので修正します。