### PR TITLE
サーバーにタイムアウト設定

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.12
+    rev: v8.13.0
     hooks:
       - id: gitleaks

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -105,7 +106,13 @@ func main() {
 	mux.Handle("/ping", http.HandlerFunc(pingHandle))
 	mux.Handle("/webhooks", http.HandlerFunc(webhookHandle))
 
-	if err := http.ListenAndServe(":"+os.Getenv("PORT"), mux); err != nil {
+	server := &http.Server{
+		Addr:         ":" + os.Getenv("PORT"),
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Panicln(err)
 	}
 }


### PR DESCRIPTION
https://github.com/dev-hato/deploy-webhook/actions/runs/3204149982/jobs/5235102492

```
main.go:108:12: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
```

また、上記エラーに対処します。