### PR TITLE
Replace set-output by $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -87,7 +87,7 @@ jobs:
           CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run deploy-webhook sh -c "${CMD}")
           echo "Go version:" "${go_version}"
-          echo "::set-output name=go_version::${go_version}"
+          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@v3
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -87,7 +87,7 @@ jobs:
           CMD="go version | awk '{print \$3}' | sed -e 's/^go//g'"
           go_version=$(docker compose -f docker-compose.yml -f dev.docker-compose.yml run deploy-webhook sh -c "${CMD}")
           echo "Go version:" "${go_version}"
-          echo "go_version=${go_version}" >> $GITHUB_OUTPUT
+          echo "go_version=${go_version}" >> "${GITHUB_OUTPUT}"
       - name: Set up Go
         uses: actions/setup-go@v3
         if: github.event_name != 'pull_request' || github.event.action != 'closed'


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
set-output が非推奨になるらしいので `$GITHUB_OUTPUT` に置き換えた

```bash
find .github -name '*.yml' -exec sed -i 's/echo "::set-output name=\([a-zA-Z0-9_]*\)::\(.*\)"$/echo "\1=\2" >> $GITHUB_OUTPUT/' {} \;
```